### PR TITLE
Add benchmark's other-modules to .cabal file

### DIFF
--- a/effect-handlers.cabal
+++ b/effect-handlers.cabal
@@ -100,6 +100,8 @@ benchmark benchm
   default-language:    Haskell2010
   hs-source-dirs:      bench, test
   main-is:             TestBench.hs
+  other-modules:       Examples.Combined
+                       Examples.Reader
   build-depends:       base >=4.7 && <5
                      , effect-handlers
                      , criterion >= 1.0 && <2


### PR DESCRIPTION
`Examples.Combined` and `Examples.Reader` aren't listed in the `other-modules` of the `.cabal`, so as a result, they aren't distributed with `cabal sdist`, causing the benchmarks to fail to compile from Hackage.

See also https://github.com/fpco/stackage/issues/1372#issuecomment-213020065
